### PR TITLE
[#957] Fixed updated README.md to correctly state that STUMPY supports Python 3.8+ updated pypi.sh to reference step a) pyproject.toml instead of the decomissioned setup.py and ultimately scanned the full repository for any listings of outdated references to STUMPY supporting Python 3.7 (I was unable to find any)

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -49,7 +49,7 @@ check_errs()
 check_black()
 {
     echo "Checking Black Code Formatting"
-    black --check --exclude=".*\.ipynb"  --diff ./
+    black --check --exclude=".*\.ipynb" --diff ./
     check_errs $?
 }
 

--- a/test.sh
+++ b/test.sh
@@ -15,6 +15,8 @@ do
         test_mode="coverage"
     elif [[ $var == "notebooks" ]]; then
         test_mode="notebooks"
+    elif [[ $var == "gpu" ]] || [[ $var == "gpus" ]]; then
+        test_mode="gpu"
     elif [[ $var == "custom" ]]; then
         test_mode="custom"
     elif [[ $var == "silent" || $var == "print" ]]; then
@@ -164,6 +166,17 @@ test_coverage()
     coverage report -m --fail-under=100 --skip-covered --omit=setup.py,docstring.py,min.py,stumpy/cache.py
 }
 
+test_gpu()
+{
+    echo "Testing Numba JIT CUDA GPU Compiled Functions"
+    #for testfile in tests/test_*gpu*.py tests/test_core.py tests/test_precision.py tests/test_non_normalized_decorator.py
+    for testfile in $(grep gpu tests/* | awk -v FS=':' '{print $1}' | uniq);
+    do
+        pytest -rsx -W ignore::RuntimeWarning -W ignore::DeprecationWarning -W ignore::UserWarning $testfile
+        check_errs $?
+    done
+}
+
 check_links()
 {
     echo "Checking notebook links"
@@ -221,6 +234,9 @@ elif [[ $test_mode == "custom" ]]; then
     # export NUMBA_DISABLE_JIT=1
     # export NUMBA_ENABLE_CUDASIM=1
     test_custom
+elif [[ $test_mode == "gpu" ]]; then
+    echo "Executing GPU Unit Tests Only"
+    test_gpu
 elif [[ $test_mode == "links" ]]; then
     echo "Check Notebook Links  Only"
     check_links

--- a/test.sh
+++ b/test.sh
@@ -17,6 +17,8 @@ do
         test_mode="notebooks"
     elif [[ $var == "gpu" ]] || [[ $var == "gpus" ]]; then
         test_mode="gpu"
+    elif [[ $var == "show" ]]; then
+        test_mode="show"
     elif [[ $var == "custom" ]]; then
         test_mode="custom"
     elif [[ $var == "silent" || $var == "print" ]]; then
@@ -177,6 +179,18 @@ test_gpu()
     done
 }
 
+show()
+{
+    echo "Current working directory: " `pwd`
+    echo "Black version: " `python -c "import black; print(black.__version__)"`
+    echo "Flake8 versoin: " `python -c "import flake8; print(flake8.__version__)"`
+    echo "Python version: " `python -c "import platform; print(platform.python_version())"`
+    echo "NumPy version: " `python -c "import numpy; print(numpy.__version__)"`
+    echo "SciPy version: " `python -c "import scipy; print(scipy.__version__)"`
+    echo "Numba version: " `python -c "import numba; print(numba.__version__)"` 
+    exit 0
+}
+
 check_links()
 {
     echo "Checking notebook links"
@@ -209,6 +223,11 @@ convert_notebooks()
 ###########
 #   Main  #
 ###########
+
+if [[ $test_mode == "show" ]]; then
+    echo "Show development/test environment"
+    show
+fi
 
 clean_up
 check_black


### PR DESCRIPTION
# Pull Request Checklist

Below is a simple checklist but please do not hesitate to ask for assistance!

- [x] Fork, clone, and checkout the newest version of the code
- [x] Create a new branch
- [x] Make necessary code changes
- [x] Install `black` (i.e., `python -m pip install black` or `conda install -c conda-forge black`)
- [x] Install `flake8` (i.e., `python -m pip install flake8` or `conda install -c conda-forge flake8`)
- [x] Install `pytest-cov` (i.e., `python -m pip install pytest-cov` or `conda install -c conda-forge pytest-cov`)
- [x] Run `black .` in the root stumpy directory
- [x] Run `flake8 .` in the root stumpy directory
- [x] Run `./setup.sh && ./test.sh` in the root stumpy directory
- [x] Reference a Github issue (and create one if one doesn't already exist)
